### PR TITLE
1 creating auth using jwt

### DIFF
--- a/app/routers/authentication_router.py
+++ b/app/routers/authentication_router.py
@@ -6,7 +6,7 @@ from sqlmodel import Session
 
 from app.databases.session import get_session
 from app.models.user_model import User
-from app.schemas.token_schema import LogoutRequest
+from app.schemas.token_schema import TokenRequest
 from app.schemas.user_schema import UserCreate, UserRead
 from app.services.authentication_service import authenticate_user, create_access_token, create_user, get_current_active_user, create_refresh_token, logout_user, revoke_refresh_token, validate_refresh_token
 from app.schemas.token_schema import Token
@@ -71,12 +71,12 @@ def register(user_in: UserCreate, session: Session = Depends(get_session)):
         
 @router.post("/refresh")
 def refresh_access_token(
-    refresh_token_raw: str,
+    data: TokenRequest,
     session: Session = Depends(get_session)
 ):
     try:
         # 1. Validate refresh token
-        refresh_token = validate_refresh_token(session, refresh_token_raw)
+        refresh_token = validate_refresh_token(session, data.refresh_token)
         if not refresh_token:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -110,7 +110,7 @@ def refresh_access_token(
         
 @router.post("/logout")
 def logout(
-    data: LogoutRequest,
+    data: TokenRequest,
     authorization: str = Header(...),
     session: Session = Depends(get_session)
 ):

--- a/app/schemas/token_schema.py
+++ b/app/schemas/token_schema.py
@@ -8,5 +8,5 @@ class Token(BaseModel):
 class TokenData(BaseModel):
     user_id: int
     
-class LogoutRequest(BaseModel):
+class TokenRequest(BaseModel):
     refresh_token: str

--- a/app/services/authentication_service.py
+++ b/app/services/authentication_service.py
@@ -116,7 +116,7 @@ def create_refresh_token(session: Session, user_id: int) -> str:
     refresh_token = RefreshToken(
         user_id=user_id,
         token_hash=token_hash,
-        expires_at=datetime.utcnow() + timedelta(hours=REFRESH_TOKEN_EXPIRE_HOURS)
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=REFRESH_TOKEN_EXPIRE_HOURS)
     )
     
     session.add(refresh_token)
@@ -137,7 +137,7 @@ def validate_refresh_token(session: Session, token: str) -> RefreshToken | None:
     if not refresh_token:
         return None
     
-    if refresh_token.expires_at < datetime.now():
+    if refresh_token.expires_at.replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
         return None
     
     return refresh_token


### PR DESCRIPTION
## Fixing in refresh_token and logout function.

In this case if the token_access is already expired than use the refresh_token to get a new token using fresh token so the user doesn't need to login manually again. But refresh token only works in 3 hours and the if expires the user need to login manually. 