### PR TITLE
feat: making popular_items API endpoint support with pagination

### DIFF
--- a/app/routers/history_router.py
+++ b/app/routers/history_router.py
@@ -1,6 +1,7 @@
 import traceback
 
 from typing import List, Annotated
+from fastapi.params import Query
 from sqlmodel import Session
 from fastapi import APIRouter, Depends, HTTPException
 
@@ -11,28 +12,6 @@ from app.services.history_service import get_popular_items, get_recommendations
 from app.services.authentication_service import get_current_active_user
 
 router = APIRouter(prefix="/history", tags=["history"])
-
-@router.get("/popular", response_model=ResponsePopularItem)
-def popular_items(
-    session: Session = Depends(get_session),
-    current_user: User = Depends(get_current_active_user)
-):
-    try:
-        items = get_popular_items(session)
-
-        clean_items = [PopularItem.model_validate(item) for item in items]
-
-        response = {
-            "status": "success",
-            "message": "Popular items fetched successfully",
-            "data": clean_items
-        }
-
-        return response
-
-    except Exception as e:
-        traceback.print_exc()
-        raise HTTPException(500, f"Error fetching popular items: {str(e)}")
 
 @router.get("/recommendation/{id}")
 def get_recommendation_endpoint(
@@ -53,3 +32,33 @@ def get_recommendation_endpoint(
         message="Recommendations fetched successfully",
         data=recommendations
     )
+
+@router.get("/popular", response_model=ResponsePopularItem)
+def popular_items(
+    session: Session = Depends(get_session),
+    current_user: User = Depends(get_current_active_user),
+    page: int = Query(1, ge=1),
+    size: int = Query(10, ge=1, le=100)
+):
+    try:
+        offset = (page - 1) * size
+
+        items = get_popular_items(
+            session,
+            limit=size,
+            offset=offset
+        )
+
+        clean_items = [PopularItem.model_validate(item) for item in items]
+
+        response = {
+            "status": "success",
+            "message": "Popular items fetched successfully",
+            "data": clean_items
+        }
+
+        return response
+
+    except Exception as e:
+        traceback.print_exc()
+        raise HTTPException(500, f"Error fetching popular items: {str(e)}")

--- a/app/services/history_service.py
+++ b/app/services/history_service.py
@@ -97,7 +97,11 @@ def get_recommendations(session: Session, user_id: int) -> List | None:
         
     return recommendations
 
-def get_popular_items(session: Session):
+def get_popular_items(
+        session: Session,
+        limit: int,
+        offset: int
+):
     
     seven_days_history = datetime.now(timezone.utc) - timedelta(days=7)
 
@@ -107,7 +111,8 @@ def get_popular_items(session: Session):
         .where(History.viewed_at >= seven_days_history)
         .group_by(Item.id)
         .order_by(desc("popularity_count"))
-        .limit(10)
+        .offset(offset)
+        .limit(limit)
     )
 
     results = session.exec(statement).all()


### PR DESCRIPTION
Add pagination support to popular_items API endpoint
- get the offset (number of page)
- get the limit (number of list within each page)